### PR TITLE
update site_url in mkdocs.yml 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: FastRTC
 site_url: https://fastrtc.org
 repo_name: fastrtc
-repo_url: https://github.com/freddyaboulton/gradio-webrtc
+repo_url: https://github.com/freddyaboulton/fastrtc
 theme:
   name: material
   custom_dir: overrides


### PR DESCRIPTION
I noticed that the <link rel="canonical" href="https://sitename.example/"> isn't rendered properly. This updates that in the config. 