### PR TITLE
Set ice candidates server

### DIFF
--- a/backend/fastrtc/stream.py
+++ b/backend/fastrtc/stream.py
@@ -122,6 +122,8 @@ class Stream(WebRTCConnectionMixin):
             rtp_params: Optional dictionary of RTP encoding parameters.
             rtc_configuration: Optional Callable or dictionary for RTCPeerConnection configuration (e.g., ICE servers).
                                Required when deploying on Colab or Spaces.
+            server_rtc_configuration: Optional dictionary for RTCPeerConnection configuration on the server side. Note
+                                      that setting iceServers to be an empty list will mean no ICE servers will be used in the server.
             track_constraints: Optional dictionary of constraints for media tracks (e.g., resolution, frame rate).
             additional_inputs: Optional list of extra Gradio input components.
             additional_outputs: Optional list of extra Gradio output components. Requires `additional_outputs_handler`.

--- a/backend/fastrtc/stream.py
+++ b/backend/fastrtc/stream.py
@@ -102,6 +102,7 @@ class Stream(WebRTCConnectionMixin):
         allow_extra_tracks: bool = False,
         rtp_params: dict[str, Any] | None = None,
         rtc_configuration: RTCConfigurationCallable | None = None,
+        server_rtc_configuration: dict[str, Any] | None = None,
         track_constraints: dict[str, Any] | None = None,
         additional_inputs: list[Component] | None = None,
         additional_outputs: list[Component] | None = None,
@@ -149,6 +150,9 @@ class Stream(WebRTCConnectionMixin):
         self.track_constraints = track_constraints
         self.webrtc_component: WebRTC
         self.rtc_configuration = rtc_configuration
+        self.server_rtc_configuration = self.convert_to_aiortc_format(
+            server_rtc_configuration
+        )
         self._ui = self._generate_default_ui(ui_args)
         self._ui.launch = self._wrap_gradio_launch(self._ui.launch)
 

--- a/backend/fastrtc/webrtc.py
+++ b/backend/fastrtc/webrtc.py
@@ -113,6 +113,8 @@ class WebRTC(Component, WebRTCConnectionMixin):
             key: if assigned, will be used to assume identity across a re-render. Components that have the same key across a re-render will have their value preserved.
             mirror_webcam: if True webcam will be mirrored. Default is True.
             rtc_configuration: WebRTC configuration options. See https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection . If running the demo on a remote server, you will need to specify a rtc_configuration. See https://freddyaboulton.github.io/gradio-webrtc/deployment/
+            server_rtc_configuration: Optional dictionary for RTCPeerConnection configuration on the server side. Note
+                                      that setting iceServers to be an empty list will mean no ICE servers will be used in the server.
             track_constraints: Media track constraints for WebRTC. For example, to set video height, width use {"width": {"exact": 800}, "height": {"exact": 600}, "aspectRatio": {"exact": 1.33333}}
             time_limit: Maximum duration in seconds for recording.
             allow_extra_tracks: Allow tracks not supported by the modality. For example, a peer connection with an audio track would be allowed even if modality is 'video', which normally throws a ``ValueError`` exception.

--- a/backend/fastrtc/webrtc.py
+++ b/backend/fastrtc/webrtc.py
@@ -79,6 +79,7 @@ class WebRTC(Component, WebRTCConnectionMixin):
         key: int | str | None = None,
         mirror_webcam: bool = True,
         rtc_configuration: dict[str, Any] | None | RTCConfigurationCallable = None,
+        server_rtc_configuration: dict[str, Any] | None = None,
         track_constraints: dict[str, Any] | None = None,
         time_limit: float | None = None,
         allow_extra_tracks: bool = False,
@@ -131,6 +132,9 @@ class WebRTC(Component, WebRTCConnectionMixin):
         self.mirror_webcam = mirror_webcam
         self.concurrency_limit = 1
         self.rtc_configuration = rtc_configuration
+        self.server_rtc_configuration = self.convert_to_aiortc_format(
+            server_rtc_configuration
+        )
         self.allow_extra_tracks = allow_extra_tracks
         self.mode = mode
         self.modality = modality

--- a/backend/fastrtc/webrtc_connection_mixin.py
+++ b/backend/fastrtc/webrtc_connection_mixin.py
@@ -203,13 +203,9 @@ class WebRTCConnectionMixin:
             pc = self.pcs[webrtc_id]
             if pc.connectionState != "closed":
                 try:
-                    # Parse the candidate string from the browser
                     candidate_str = body["candidate"].get("candidate", "")
 
                     # Example format: "candidate:2393089663 1 udp 2122260223 192.168.86.60 63692 typ host generation 0 ufrag LkZb network-id 1 network-cost 10"
-                    # We need to parse this string to extract the required fields
-
-                    # Parse the candidate string
                     parts = candidate_str.split()
                     if len(parts) >= 10 and parts[0].startswith("candidate:"):
                         foundation = parts[0].split(":", 1)[1]

--- a/demo/talk_to_sambanova/app.py
+++ b/demo/talk_to_sambanova/app.py
@@ -13,6 +13,7 @@ from fastrtc import (
     AdditionalOutputs,
     ReplyOnPause,
     Stream,
+    get_cloudflare_turn_credentials,
     get_cloudflare_turn_credentials_async,
     get_stt_model,
 )
@@ -76,6 +77,7 @@ stream = Stream(
     additional_outputs_handler=lambda *a: (a[2], a[3]),
     concurrency_limit=20 if get_space() else None,
     rtc_configuration=get_cloudflare_turn_credentials_async,
+    server_rtc_configuration=get_cloudflare_turn_credentials(ttl=36_000),
 )
 
 app = FastAPI()

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,7 +13,7 @@ Cloudflare also offers a managed TURN server with [Cloudflare Calls](https://www
 Cloudflare and Hugging Face have partnered to allow you to stream 10gb of WebRTC traffic per month for free with a Hugging Face account!
 
 ```python
-from fastrtc import Stream, get_cloudflare_turn_credentials_async
+from fastrtc import Stream, get_cloudflare_turn_credentials_async, get_cloudflare_turn_credentials
 
 # Make sure the HF_TOKEN environment variable is set
 # Or pass in a callable with all arguments set
@@ -26,11 +26,14 @@ async def get_credentials():
 stream = Stream(
     handler=...,
     rtc_configuration=get_credentials,
+    server_rtc_configuration=get_cloudflare_turn_credentials(ttl=360_000)
     modality="audio",
     mode="send-receive",
 )
 ```
 
+!!! tip
+    Setting an rtc configuration in the server is recommended but not required. It's a good practice to set short lived credentials in the client (default `ttl` value of 10 minutes when calling `get_cloudflare_turn_credentials*`) but you can share the same credentials between server and client. 
 
 ### With a Cloudflare API Token
 

--- a/docs/reference/stream.md
+++ b/docs/reference/stream.md
@@ -39,7 +39,8 @@ This class encapsulates the logic for handling real-time communication (WebRTC) 
 | `additional_outputs_handler`   | `Callable \| None`                            | Handler for additional outputs.                                          |
 | `track_constraints`            | `dict[str, Any] \| None`                      | Constraints for media tracks (e.g., resolution).                         |
 | `webrtc_component`             | `WebRTC`                                      | The underlying Gradio WebRTC component instance.                         |
-| `rtc_configuration`            | `dict[str, Any] \| None`                      | Configuration for the RTCPeerConnection (e.g., ICE servers).             |
+| `rtc_configuration`            | `dict[str, Any] \| None \| Callable`          | Configuration for the RTCPeerConnection (e.g., ICE servers).             |
+| `server_rtc_configuration`     | `dict[str, Any] \| None`                      | Configuration for the RTCPeerConnection (e.g., ICE servers) to be used in the server |
 | `_ui`                          | `Blocks`                                      | The Gradio Blocks UI instance.                                           |
 
 ## Methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastrtc"
-version = "0.0.21"
+version = "0.0.22.rc2"
 description = "The realtime communication library for Python"
 readme = "README.md"
 license = "MIT"
@@ -28,17 +28,17 @@ keywords = [
   "video processing",
   "gradio-custom-component",
 ]
-# Add dependencies here
 dependencies = [
   "gradio>=4.0,<6.0",
   "aiortc",
+  "aioice>=0.10.1",
   "audioop-lts;python_version>='3.13'",
   "librosa",
   "numpy>=2.0.2",                          # because of librosa
   "numba>=0.60.0",
   "standard-aifc;python_version>='3.13'",
   "standard-sunau;python_version>='3.13'",
-]
+] # Add dependencies here
 classifiers = [
   'Development Status :: 3 - Alpha',
   'Operating System :: OS Independent',


### PR DESCRIPTION
Adds a server_rtc_configuration parameter to be able to set ICEcandidates in the server.

@whitphx would appreciate if you could review! 

You can test the change here: https://huggingface.co/spaces/fastrtc/talk-to-sambanova-gradio or https://huggingface.co/spaces/fastrtc/talk-to-sambanova 

