### PR TITLE
Fix Websocket Client Processing

### DIFF
--- a/demo/webrtc_vs_websocket/app.py
+++ b/demo/webrtc_vs_websocket/app.py
@@ -83,7 +83,7 @@ chatbot = gr.Chatbot(type="messages")
 stream = Stream(
     modality="audio",
     mode="send-receive",
-    handler=ReplyOnPause(response),
+    handler=ReplyOnPause(response, input_sample_rate=24_000, output_sample_rate=24_000),
     additional_outputs_handler=lambda a, b: b,
     additional_inputs=[chatbot],
     additional_outputs=[chatbot],

--- a/demo/webrtc_vs_websocket/index.html
+++ b/demo/webrtc_vs_websocket/index.html
@@ -390,35 +390,8 @@
             rttValues: []
         };
 
-        // Load mu-law library
-
-        // Add load promise to track when the script is ready
-
-
-        function resample(audioData, fromSampleRate, toSampleRate) {
-            const ratio = fromSampleRate / toSampleRate;
-            const newLength = Math.round(audioData.length / ratio);
-            const result = new Float32Array(newLength);
-
-            for (let i = 0; i < newLength; i++) {
-                const position = i * ratio;
-                const index = Math.floor(position);
-                const fraction = position - index;
-
-                if (index + 1 < audioData.length) {
-                    result[i] = audioData[index] * (1 - fraction) + audioData[index + 1] * fraction;
-                } else {
-                    result[i] = audioData[index];
-                }
-            }
-            return result;
-        }
 
         function convertToMulaw(audioData, sampleRate) {
-            // Resample to 8000 Hz if needed
-            if (sampleRate !== 8000) {
-                audioData = resample(audioData, sampleRate, 8000);
-            }
 
             // Convert float32 [-1,1] to int16 [-32768,32767]
             const int16Data = new Int16Array(audioData.length);
@@ -449,7 +422,7 @@
                 wsMetrics.startTime = performance.now();
 
                 // Create audio context and analyser for visualization
-                const audioContext = new AudioContext();
+                const audioContext = new AudioContext({ sampleRate: 24000 });
                 const analyser = audioContext.createAnalyser();
                 const source = audioContext.createMediaStreamSource(stream);
                 source.connect(analyser);


### PR DESCRIPTION
Closes #284

The issue was that we always resampled the audio to 8khz which would mean that any other sample rate would probably cause an issue. We should only sample to-from 8khz when connecting over the phone. For all other use cases, the input sample rate sent by the client should match `input_sample_rate` set in the handler. The server will return audio with a sample rate matching the `output_sample_rate` of the handler.

How to test:
- Run the server script and client scripts separately
- Note how the client will resample the audio to 24k hz sample rate before sending to the server. The server will also send audio back in 24k hz. That's why we write the audio file with 24k hz in `receive_audio_stream`

Server

```python
from fastrtc import AsyncStreamHandler, wait_for_item, Stream
import asyncio
import numpy as np
from fastapi import FastAPI

app = FastAPI()


class AsyncEchoHandler(AsyncStreamHandler):
    """Simple Async Echo Handler"""

    def __init__(self) -> None:
        super().__init__(input_sample_rate=24_000, output_sample_rate=24_000)
        self.queue = asyncio.Queue()

    async def receive(self, frame: tuple[int, np.ndarray]) -> None:
        await self.queue.put(frame)

    async def emit(self) -> None:
        print("emit")
        return await self.queue.get()

    def copy(self):
        return AsyncEchoHandler()

    async def shutdown(self):
        pass

    async def start_up(self) -> None:
        pass


stream = Stream(AsyncEchoHandler(), mode="send-receive", modality="audio")
stream.mount(app)

if __name__ == "__main__":
    import uvicorn

    uvicorn.run(app, port=8000)
```

Client Script (python)
```python
import argparse
import asyncio
import base64
import json
import wave
import audioop
import numpy as np
import websockets
import soundfile as sf
import librosa
from fastrtc.utils import audio_to_float32, audio_to_int16
from pydub import AudioSegment


async def send_audio_stream(
    file_path,
    websocket: websockets.ClientConnection,
    webrtc_id,
    stop_event: asyncio.Event,
    target_sample_rate: int,
):
    start_msg = {"event": "start", "websocket_id": webrtc_id}
    await websocket.send(json.dumps(start_msg))
    print("Sent start message via WebSocket.")

    # Load audio file with soundfile for resampling capabilities
    audio_data, original_sample_rate = sf.read(file_path)
    audio_data = audio_data.astype(np.float32)

    # Resample if needed
    if original_sample_rate != target_sample_rate:
        print(f"Resampling from {original_sample_rate}Hz to {target_sample_rate}Hz")
        audio_data = librosa.resample(
            audio_data, orig_sr=original_sample_rate, target_sr=target_sample_rate
        )

    # Convert to int16 for compatibility with μ-law encoding
    if audio_data.dtype != np.int16:
        audio_data = audio_to_int16(audio_data)

    # Get audio parameters
    num_channels = 1 if len(audio_data.shape) == 1 else audio_data.shape[1]
    sample_width = 2  # int16 = 2 bytes

    print(
        f"Streaming {webrtc_id} '{file_path}': {target_sample_rate} Hz, {sample_width * 8}-bit, {num_channels} channel(s)"
    )

    # Process in chunks
    frames_per_chunk = 2048
    chunk_duration = frames_per_chunk / target_sample_rate

    # Process audio in chunks
    for i in range(0, len(audio_data), frames_per_chunk):
        chunk = audio_data[i : i + frames_per_chunk]

        # Handle mono/stereo conversion
        if num_channels > 1:
            chunk = chunk[:, 0]  # Take first channel

        # Convert to bytes
        chunk_bytes = chunk.tobytes()

        # Apply μ-law encoding
        try:
            ulaw_data = audioop.lin2ulaw(chunk_bytes, sample_width)
        except Exception as e:
            print("Error during μ-law conversion:", e)
            continue

        base64_audio = base64.b64encode(ulaw_data).decode("ascii")
        media_msg = {"event": "media", "media": {"payload": base64_audio}}
        await websocket.send(json.dumps(media_msg))
        await asyncio.sleep(chunk_duration)

    stop_event.set()
    print("Finished streaming the file.")


async def receive_audio_stream(
    websocket: websockets.ClientConnection,
    stop_event: asyncio.Event,
    target_sample_rate: int,
):
    buffer = []

    while not stop_event.is_set():
        try:
            message = await asyncio.wait_for(websocket.recv(), timeout=1)
        except (asyncio.TimeoutError, TimeoutError):
            continue
        message = json.loads(message)
        if message["event"] == "media":
            audio_data = base64.b64decode(message["media"]["payload"])
            audio_array = np.frombuffer(audioop.ulaw2lin(audio_data, 2), dtype=np.int16)
            buffer.append(audio_array)
    audio_file = np.concatenate(buffer)
    print("audio_file length", len(audio_file))
    print("writing to file")
    sf.write("output.wav", audio_file, 24_000, subtype="PCM_16")


async def main_async(
    file_path, ws_uri, updates_base_url, webrtc_id, target_sample_rate
):
    event = asyncio.Event()
    async with websockets.connect(ws_uri) as ws:
        audio_task = asyncio.create_task(
            send_audio_stream(file_path, ws, webrtc_id, event, target_sample_rate)
        )
        updates_task = asyncio.create_task(
            receive_audio_stream(ws, event, target_sample_rate)
        )
        await asyncio.gather(audio_task, updates_task)


def main():
    parser = argparse.ArgumentParser(
        description=(
            "CLI Python application that streams a WAV file via WebSocket using μ-law encoding, "
            "and concurrently listens for update messages via SSE from the `/updates` endpoint."
        )
    )
    parser.add_argument("file", help="Path to the WAV file to stream.")
    parser.add_argument(
        "--ws-server",
        default="ws://localhost:8000/websocket/offer",
        help="WebSocket server URI (default: ws://localhost:8000/websocket/offer).",
    )
    parser.add_argument(
        "--updates-server",
        default="http://localhost:8000",
        help="Base URL for the updates endpoint (default: http://localhost:8000).",
    )
    parser.add_argument(
        "--webrtc-id",
        required=True,
        help="WebRTC ID to be passed to the updates endpoint.",
    )
    parser.add_argument(
        "--sample-rate",
        type=int,
        default=24_000,
        help="Target sample rate for audio streaming (default: 22050 Hz).",
    )
    args = parser.parse_args()

    asyncio.run(
        main_async(
            args.file,
            args.ws_server,
            args.updates_server,
            args.webrtc_id,
            args.sample_rate,
        )
    )


if __name__ == "__main__":
    main()
```