### PR TITLE
fix: fail to use CLOUDFLARE_TURN_KEY_* even if HF_TOKEN is missing

### DIFF
--- a/backend/fastrtc/credentials.py
+++ b/backend/fastrtc/credentials.py
@@ -137,7 +137,7 @@ def get_cloudflare_turn_credentials(
     """
     if hf_token is None:
         hf_token = os.getenv("HF_TOKEN")
-    if hf_token is not None:
+    if hf_token:
         return httpx.get(
             CLOUDFLARE_FASTRTC_TURN_URL,
             headers={"Authorization": f"Bearer {hf_token}"},


### PR DESCRIPTION
only use `HF_TOKEN` if it's not an empty value to allow fallback to `CLOUDFLARE_TURN_KEY_*`