### PR TITLE
Feat: FastRTC version of Whisper CPP speech to text to Docs

### DIFF
--- a/docs/speech_to_text_gallery.md
+++ b/docs/speech_to_text_gallery.md
@@ -82,6 +82,21 @@ document.querySelectorAll('.tag-button').forEach(button => {
 
     [:octicons-code-16: Repository](https://github.com/sgarg26/fastrtc-kroko)
 
+-   :speaking_head:{ .lg .middle }:eyes:{ .lg .middle } fastrtc-whisper-cpp 
+{: data-tags="whisper-cpp"}
+
+    ---
+
+    Description:
+    [whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp) is the ggml version of OpenAI's Whisper model. 
+
+    Install Instructions
+    ```python
+    pip install fastrtc-whisper-cpp
+    ```
+    Check out the fastrtc-whisper-cpp docs for examples!
+
+    [:octicons-code-16: Repository](https://github.com/mahimairaja/fastrtc-whisper-cpp)
 
 -   :speaking_head:{ .lg .middle }:eyes:{ .lg .middle } __Your STT Model__
 {: data-tags="pytorch"}


### PR DESCRIPTION
# What does this PR does? 

- [x] Add documentation for FastRTC Whisper CPP

## Relevant Links

PyPI: https://pypi.org/project/fastrtc-whisper-cpp/

Repo: https://github.com/mahimairaja/fastrtc-whisper-cpp

Issue - [here](https://github.com/gradio-app/fastrtc/issues/165)

### Installation 

```
$ pip install "fastrtc-whisper-cpp[audio]" 

# load_audio internally uses librosa - optional dependency
```

### Demo script:

``` python
from fastrtc_whisper_cpp import get_stt_model, load_audio

model = get_stt_model(model="base.en")

audio_data = load_audio("test.wav")

text = model.stt(audio_data)

print(f'Transcription: {text}')
```


#### With FastRTC

```python
from fastrtc import (ReplyOnPause, Stream, get_tts_model)
from fastrtc_whisper_cpp import get_stt_model
from openai import OpenAI


client = OpenAI()

stt_model = get_stt_model()
tts_model = get_tts_model()

def echo(audio):
    prompt = stt_model.stt(audio)
    response = client.chat.completions.create(
        model="gpt-4o",
        messages=[{"role": "user", "content": prompt}],
        max_tokens=200,
    )
    prompt = response.choices[0].message.content
    for audio_chunk in tts_model.stream_tts_sync(prompt):
        yield audio_chunk

stream = Stream(ReplyOnPause(echo), modality="audio", mode="send-receive")

stream.ui.launch()
```