### PR TITLE
Pass Websocket to the context if available

### DIFF
--- a/backend/fastrtc/utils.py
+++ b/backend/fastrtc/utils.py
@@ -16,6 +16,7 @@ from typing import Any, Literal, Protocol, TypedDict, cast
 import av
 import librosa
 import numpy as np
+from fastapi import WebSocket
 from numpy.typing import NDArray
 from pydub import AudioSegment
 
@@ -67,6 +68,7 @@ current_channel: ContextVar[DataChannel | None] = ContextVar(
 @dataclass
 class Context:
     webrtc_id: str
+    websocket: WebSocket | None = None
 
 
 current_context: ContextVar[Context | None] = ContextVar(

--- a/backend/fastrtc/websocket.py
+++ b/backend/fastrtc/websocket.py
@@ -94,21 +94,14 @@ class WebSocketHandler:
         await websocket.accept()
         loop = asyncio.get_running_loop()
         self.loop = loop
-        self.websocket = websocket
         self.data_channel = WebSocketDataChannel(websocket, loop)
         self.stream_handler._loop = loop
         self.stream_handler.set_channel(self.data_channel)
         self._emit_task = asyncio.create_task(self._emit_loop())
         self._emit_to_queue_task = asyncio.create_task(self._emit_to_queue())
         self._frame_cleanup_task = asyncio.create_task(self._cleanup_frames_loop())
-        if isinstance(self.stream_handler, AsyncStreamHandler):
-            start_up = self.stream_handler.start_up()
-        else:
-            start_up = anyio.to_thread.run_sync(self.stream_handler.start_up)  # type: ignore
-
         was_disconnected = False
 
-        self.start_up_task = asyncio.create_task(start_up)
         try:
             while not self.quit.is_set():
                 if websocket.application_state != WebSocketState.CONNECTED:
@@ -157,7 +150,20 @@ class WebSocketHandler:
                         self.stream_id = cast(str, message["streamSid"])
                     else:
                         self.stream_id = cast(str, message["websocket_id"])
-                    current_context.set(Context(webrtc_id=self.stream_id))
+                    self.websocket = websocket
+                    current_context.set(
+                        Context(webrtc_id=self.stream_id, websocket=websocket)
+                    )
+                    if isinstance(self.stream_handler, AsyncStreamHandler):
+                        start_up = self.stream_handler.start_up()
+                    else:
+                        start_up = anyio.to_thread.run_sync(
+                            self.stream_handler.start_up
+                        )  # type: ignore
+
+                    self.start_up_task = asyncio.create_task(start_up)
+
+                    print("Set context")
                     self.set_additional_outputs = self.set_additional_outputs_factory(
                         self.stream_id
                     )
@@ -189,11 +195,15 @@ class WebSocketHandler:
             self.clean_up(cast(str, self.stream_id))
 
     def emit_with_context(self):
-        current_context.set(Context(webrtc_id=cast(str, self.stream_id)))
+        current_context.set(
+            Context(webrtc_id=cast(str, self.stream_id), websocket=self.websocket)
+        )
         return self.stream_handler.emit()
 
     def receive_with_context(self, frame: tuple[int, np.ndarray]):
-        current_context.set(Context(webrtc_id=cast(str, self.stream_id)))
+        current_context.set(
+            Context(webrtc_id=cast(str, self.stream_id), websocket=self.websocket)
+        )
         return self.stream_handler.receive(frame)
 
     async def _emit_to_queue(self):


### PR DESCRIPTION
Closes #303 


The websocket instance is not available in the context, so you can send custom websocket messages from the handler

```python
import asyncio
import base64
import json
from pathlib import Path

import gradio as gr
import numpy as np
import openai
from dotenv import load_dotenv
from fastapi import FastAPI
from fastapi.responses import HTMLResponse, StreamingResponse
from fastrtc import (
    AdditionalOutputs,
    AsyncStreamHandler,
    Stream,
    get_current_context,
    get_twilio_turn_credentials,
    wait_for_item,
)
from gradio.utils import get_space

load_dotenv()

cur_dir = Path(__file__).parent

SAMPLE_RATE = 24000


class OpenAIHandler(AsyncStreamHandler):
    def __init__(
        self,
    ) -> None:
        super().__init__(
            expected_layout="mono",
            output_sample_rate=SAMPLE_RATE,
            input_sample_rate=SAMPLE_RATE,
        )
        self.connection = None
        self.output_queue = asyncio.Queue()

    def copy(self):
        return OpenAIHandler()

    async def start_up(
        self,
    ):
        """Connect to realtime API. Run forever in separate thread to keep connection open."""
        self.client = openai.AsyncOpenAI()
        async with self.client.beta.realtime.connect(
            model="gpt-4o-mini-realtime-preview-2024-12-17"
        ) as conn:
            await conn.session.update(
                session={
                    "turn_detection": {"type": "server_vad"},
                    "input_audio_transcription": {
                        "model": "whisper-1",
                        "language": "en",
                    },
                }
            )
            self.connection = conn
            async for event in self.connection:
                # Handle interruptions
                if event.type == "input_audio_buffer.speech_started":
                    # self.clear_queue()
                    try:
                        context = get_current_context()
                        if context.websocket is not None:
                            await context.websocket.send_json(
                                {
                                    "streamSid": context.webrtc_id,
                                    "event": "clear",
                                }
                            )
                    except Exception as e:
                        print(e)
                        import traceback

                        traceback.print_exc()

                if (
                    event.type
                    == "conversation.item.input_audio_transcription.completed"
                ):
                    await self.output_queue.put(
                        AdditionalOutputs({"role": "user", "content": event.transcript})
                    )
                if event.type == "response.audio_transcript.done":
                    await self.output_queue.put(
                        AdditionalOutputs(
                            {"role": "assistant", "content": event.transcript}
                        )
                    )
                if event.type == "response.audio.delta":
                    await self.output_queue.put(
                        (
                            self.output_sample_rate,
                            np.frombuffer(
                                base64.b64decode(event.delta), dtype=np.int16
                            ).reshape(1, -1),
                        ),
                    )

    async def receive(self, frame: tuple[int, np.ndarray]) -> None:
        if not self.connection:
            return
        _, array = frame
        array = array.squeeze()
        audio_message = base64.b64encode(array.tobytes()).decode("utf-8")
        await self.connection.input_audio_buffer.append(audio=audio_message)  # type: ignore

    async def emit(self) -> tuple[int, np.ndarray] | AdditionalOutputs | None:
        return await wait_for_item(self.output_queue)

    async def shutdown(self) -> None:
        if self.connection:
            await self.connection.close()
            self.connection = None


def update_chatbot(chatbot: list[dict], response: dict):
    chatbot.append(response)
    return chatbot


chatbot = gr.Chatbot(type="messages")
latest_message = gr.Textbox(type="text", visible=False)
stream = Stream(
    OpenAIHandler(),
    mode="send-receive",
    modality="audio",
    additional_inputs=[chatbot],
    additional_outputs=[chatbot],
    additional_outputs_handler=update_chatbot,
    concurrency_limit=5 if get_space() else None,
    time_limit=90 if get_space() else None,
)

app = FastAPI()

stream.mount(app)

if __name__ == "__main__":
    stream.fastphone(host="0.0.0.0", port=7860)
```