### PR TITLE
[FIX] Allow usage of Cloudflare tokens if hf_token is missing

### DIFF
--- a/backend/fastrtc/credentials.py
+++ b/backend/fastrtc/credentials.py
@@ -208,7 +208,7 @@ async def get_cloudflare_turn_credentials_async(
 
     if hf_token is None:
         hf_token = os.getenv("HF_TOKEN", "").strip()
-    if hf_token is not None:
+    if hf_token:
         async with httpx.AsyncClient() as client:
             response = await client.get(
                 CLOUDFLARE_FASTRTC_TURN_URL,


### PR DESCRIPTION
Same issue as https://github.com/gradio-app/fastrtc/pull/307, but for `get_cloudflare_turn_credentials_async`