### PR TITLE
Fix Typos in Comments: "vertices" and "accommodate"

### DIFF
--- a/backend/fastrtc/templates/component/cytoscape.esm-C2cgT2B2.js
+++ b/backend/fastrtc/templates/component/cytoscape.esm-C2cgT2B2.js
@@ -17061,7 +17061,7 @@ var $y = /* @__PURE__ */ function() {
       // instanced
       in vec2 aPosition; // a vertex from the unit square
       
-      in mat3 aTransform; // used to transform verticies, eg into a bounding box
+      in mat3 aTransform; // used to transform vertices, eg into a bounding box
       in int aVertType; // the type of thing we are rendering
 
       // the z-index that is output when using picking mode

--- a/backend/fastrtc/templates/component/cytoscape.esm-C2cgT2B2.js
+++ b/backend/fastrtc/templates/component/cytoscape.esm-C2cgT2B2.js
@@ -17458,7 +17458,7 @@ var $y = /* @__PURE__ */ function() {
       gn(t, t, [s, o]), _s(t, t, [a.w, a.h]);
     }
     /**
-     * Adjusts a node or label BB to accomodate padding and split for wrapped textures.
+     * Adjusts a node or label BB to accommodate padding and split for wrapped textures.
      * @param bb - the original bounding box
      * @param padding - the padding to add to the bounding box
      * @param first - whether this is the first part of a wrapped texture


### PR DESCRIPTION


Description:  
This pull request corrects two typos in the comments of the file backend/fastrtc/templates/component/cytoscape.esm-C2cgT2B2.js:
- "verticies" has been corrected to "vertices"
- "accomodate" has been corrected to "accommodate"

These changes improve the clarity and accuracy of the code documentation. No functional code was modified.