### PR TITLE
change some prints to logger.

### DIFF
--- a/backend/fastrtc/tracks.py
+++ b/backend/fastrtc/tracks.py
@@ -407,7 +407,7 @@ class StreamHandlerBase(ABC):
             self.latest_args = list(args)
         else:
             self.latest_args = ["__webrtc_value__"] + list(args)
-        print("set args", self.latest_args)
+        logger.debug("set args", self.latest_args)
         self.args_set.set()
 
     def reset(self):

--- a/backend/fastrtc/utils.py
+++ b/backend/fastrtc/utils.py
@@ -261,8 +261,8 @@ async def player_worker_decode(
             import traceback
 
             exec = traceback.format_exc()
-            print("traceback %s", exec)
-            print("Error processing frame: %s", str(e))
+            logger.error("traceback %s", exec)
+            logger.error("Error processing frame: %s", str(e))
             if isinstance(e, WebRTCError):
                 raise e
             else:

--- a/backend/fastrtc/websocket.py
+++ b/backend/fastrtc/websocket.py
@@ -136,7 +136,7 @@ class WebSocketHandler:
                                 (self.stream_handler.input_sample_rate, audio_array),
                             )
                     except Exception as e:
-                        print(e)
+                        logger.error(e)
                         import traceback
 
                         traceback.print_exc()


### PR DESCRIPTION
The print in tracks.py is called quite often and may be annoying when there's a lot of info (like an image).
I guess the existing logger is better adapted for this one and some others.

I haven't touched the ones in the demos, or the `print(click.style..`