### PR TITLE
ci: add pytest workflow (matrix 3.10-3.12)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,44 @@
+name: Python CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip setuptools build
+
+      - name: Install project (dev extras)
+        run: |
+          # Install the package and dev extras so tests and tooling are available
+          python -m pip install -e '.[dev]'
+
+      - name: Run tests
+        run: |
+          pytest -q
+
+      - name: Run ruff (optional lint)
+        run: |
+          python -m pip install ruff
+          ruff check backend demo frontend || true


### PR DESCRIPTION
added a workflow for testing
Runs pytest on Python 3.10–3.12
Installs dev extras via editable install (.[dev])
Runs ruff optionally (non-failing)