### PR TITLE
Fix ICE candidate parsing

### DIFF
--- a/backend/fastrtc/webrtc_connection_mixin.py
+++ b/backend/fastrtc/webrtc_connection_mixin.py
@@ -245,8 +245,9 @@ class WebRTCConnectionMixin:
                     candidate_str = body["candidate"].get("candidate", "")
 
                     # Example format: "candidate:2393089663 1 udp 2122260223 192.168.86.60 63692 typ host generation 0 ufrag LkZb network-id 1 network-cost 10"
+                    # Also support shorter format: "candidate:0 1 UDP 2122187007 192.168.1.52 38846 typ host"
                     parts = candidate_str.split()
-                    if len(parts) >= 10 and parts[0].startswith("candidate:"):
+                    if len(parts) >= 8 and parts[0].startswith("candidate:"):
                         foundation = parts[0].split(":", 1)[1]
                         component = int(parts[1])
                         protocol = parts[2]


### PR DESCRIPTION
 in `webrtc_connection_mixin.py` fix ICE candidate validation from l`en(parts) >= 10` to `len(parts) >= 8` to comply with RFC 5245 Section 15.1.
Resolves rejection of valid Host candidates (8 tokens) and Peer-Reflexive candidates when self-reflexive peers gather without optional attributes. [RFC 5245](https://datatracker.ietf.org/doc/html/rfc5245)          