### PR TITLE
Fix a race condition with DataChannel

### DIFF
--- a/backend/fastrtc/utils.py
+++ b/backend/fastrtc/utils.py
@@ -192,9 +192,9 @@ async def player_worker_decode(
                 and channel()
             ):
                 set_additional_outputs(outputs)
-                 dc = cast(DataChannel, channel())
-                 if dc.readyState == "open":
-                     dc.send(create_message("fetch_output", []))
+                dc = cast(DataChannel, channel())
+                if dc.readyState == "open":
+                    dc.send(create_message("fetch_output", []))
 
             if frame is None:
                 if isinstance(outputs, CloseStream):

--- a/backend/fastrtc/utils.py
+++ b/backend/fastrtc/utils.py
@@ -192,7 +192,9 @@ async def player_worker_decode(
                 and channel()
             ):
                 set_additional_outputs(outputs)
-                cast(DataChannel, channel()).send(create_message("fetch_output", []))
+                 dc = cast(DataChannel, channel())
+                 if dc.readyState == "open":
+                     dc.send(create_message("fetch_output", []))
 
             if frame is None:
                 if isinstance(outputs, CloseStream):

--- a/backend/fastrtc/utils.py
+++ b/backend/fastrtc/utils.py
@@ -53,6 +53,8 @@ class CloseStream:
 
 
 class DataChannel(Protocol):
+    @property
+    def readyState(self) -> str: ...
     def send(self, message: str) -> None: ...
 
 


### PR DESCRIPTION
Fix a race condition where sending data on DC fail as it doesn't check for the readyState to be opened before sending data onto the DC.