### PR TITLE
Fix websocket emit-queue starvation when emit() returns None

### DIFF
--- a/backend/fastrtc/websocket.py
+++ b/backend/fastrtc/websocket.py
@@ -207,6 +207,11 @@ class WebSocketHandler:
                     output = await self.stream_handler.emit()
                 else:
                     output = await run_sync(self.emit_with_context)
+                if output is None:
+                    # Idle: nothing to send. Back off so the consumer _emit_loop gets
+                    # scheduled, instead of spinning put_nowait(None) and flooding the queue.
+                    await asyncio.sleep(0.02)
+                    continue
                 self.queue.put_nowait(output)
         except asyncio.CancelledError:
             logger.debug("Emit loop cancelled")


### PR DESCRIPTION
### Problem

`WebSocketHandler._emit_to_queue` enqueues whatever `emit()` returns with no guard:

```python
while not self.quit.is_set():
    output = await self.stream_handler.emit()
    self.queue.put_nowait(output)
```

When a handler is idle, `emit()` returns `None` instantly on every call. With an unbounded queue and no yield on the idle path, this spins thousands of times/sec enqueuing `None`, floods the queue (observed ~164k depth), and starves the consumer `_emit_loop` so it isn't scheduled to send the frame already at the head of the queue.

Real-world impact (telephony): up to ~18s of intermittent dead air before an already-generated greeting reached the caller. Related: #203, where the same starvation is worked around by adding `await asyncio.sleep(0.01)` inside the user's `emit()`.

### Fix

On the idle path (`output is None`), back off 20ms and skip the enqueue:

```python
if output is None:
    await asyncio.sleep(0.02)
    continue
self.queue.put_nowait(output)
```

### Why this is safe

`_emit_loop` already skips `None` outputs, so enqueuing `None` never produced a frame - it only created work and event-loop contention. This removes wasted work and yields the loop to the consumer on idle; no downstream behavior changes.

### Validation

On the live phone path, first-frame send dropped from ~18.6s to ~0.1-0.4s with queue depth ~0 on every call. Tested on `0.0.33`; the affected code is identical on `main`.

### Notes / alternatives

- 20ms is a conservative idle backoff (negligible added latency vs the starvation it prevents). Open to tuning.
- Alternatives considered: bounding the queue, or documenting the `emit()` await requirement instead of handling it here. Went with the loop-side guard because it's minimal and fixes the existing #203 workaround at the source. Happy to reshape.
